### PR TITLE
If the settings object isn't present, an empty map is returned

### DIFF
--- a/lib/banyan_api/shop.ex
+++ b/lib/banyan_api/shop.ex
@@ -133,6 +133,8 @@ defmodule BanyanAPI.Shop do
       {:error,
        "Banyan.Shop.update called with invalid parameters, received #{Kernel.inspect(args)}"}
 
+  defp remove_nil_values(nil), do: %{}
+
   defp remove_nil_values(settings) do
     settings
     |> Enum.map(fn {k, v} -> if v == nil, do: {k, ""}, else: {k, v} end)


### PR DESCRIPTION
This PR addresses this [Sentry error](https://sentry.io/organizations/pxu/issues/1180387424/?project=1393649&referrer=slack). It's possible for the `settings` property of the `shop` object to be `nil`. In which case, `remove_nil_values` should return an empty object. That way the default settings can still be used in the update.