### PR TITLE
Chore/ch56587/themebot graphql

### DIFF
--- a/lib/banyan_api/theme_bot.ex
+++ b/lib/banyan_api/theme_bot.ex
@@ -1,0 +1,36 @@
+defmodule BanyanAPI.ThemeBot do
+  alias BanyanAPI.Client
+
+  @spec create(map()) :: {:ok, %Neuron.Response{}} | {:error, any()}
+  def create(%{
+        myshopify_domain: myshopify_domain,
+        theme_id: theme_id,
+        manifest_name: manifest_name
+      }) do
+    Client.query(
+      """
+      mutation CreateThemeBot(
+        $myshopify_domain: String!,
+        $theme_id: String!,
+        $manifest_name: String!,
+        $app_name: String!
+      ) {
+        createThemeBot(
+          myshopify_domain: $myshopify_domain,
+          app_name: $app_name,
+          theme_id: $theme_id,
+          manifest_name: $manifest_name
+      ) {
+          manifest_name
+        }
+      }
+      """,
+      %{
+        myshopify_domain: myshopify_domain,
+        theme_id: theme_id,
+        manifest_name: manifest_name,
+        app_name: Application.get_env(:banyan_api, :app_name, "")
+      }
+    )
+  end
+end


### PR DESCRIPTION
## What does this do?
adds a ThemeBot module for sending `createThemeBot` mutations to Banyan.

## How does this change work?
existing patterns with Neuron. The themebot call lives under BanyanAPI, but it can be moved out to its own dependency at a later date (perhaps if/when ThemeBot and Banyan are split up?)

## How do you manually test this?
elixir-wholesale companion PR coming... but when running elixir-wholesale and Banyan, use elixir-wholesale's graphiql sandbox to trigger a `createThemeInstall` mutation. If all goes to plan, Themebot will run in Banyan!

## When should this be merged?
anytime