### PR TITLE
Raise custom error for http timeouts

### DIFF
--- a/lib/banyan_api/client.ex
+++ b/lib/banyan_api/client.ex
@@ -5,6 +5,7 @@ defmodule BanyanAPI.Client do
   alias Neuron.Config
   alias PxUAuth0.AccessToken
 
+  # Neuron specs are screwy, so this needed to match against the HTTPoison Error
   @dialyzer {:nowarn_function, log_and_return!: 1}
   @default_access_token_impl &AccessToken.fetch/0
 

--- a/lib/banyan_api/timeout_error.ex
+++ b/lib/banyan_api/timeout_error.ex
@@ -1,0 +1,3 @@
+defmodule BanyanAPI.TimeoutError do
+  defexception message: "Banyan Timeout when responding to request"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BanyanAPI.MixProject do
   use Mix.Project
 
-  @version "0.3.6"
+  @version "0.3.7"
 
   def project do
     [


### PR DESCRIPTION
When Banyan restarts our GraphQL requests timeout, throwing errors. This makes it a custom error we can safely ignore in Sentry (the jobs are rerun regardless)