### PR TITLE
pass neuron errors through from BanyanAPI client

### DIFF
--- a/lib/banyan_api/client.ex
+++ b/lib/banyan_api/client.ex
@@ -7,6 +7,7 @@ defmodule BanyanAPI.Client do
 
   @default_access_token_impl &AccessToken.fetch/0
 
+  @spec query(String.t(), map()) :: {:ok, map()} | {:error, any()}
   def query(query, params) do
     Config.set(url: Application.get_env(:banyan_api, :graphql_endpoint, ""))
     Config.set(headers: headers())

--- a/lib/banyan_api/client.ex
+++ b/lib/banyan_api/client.ex
@@ -21,14 +21,15 @@ defmodule BanyanAPI.Client do
     [Authentication: "Bearer #{auth0_token}"]
   end
 
-  defp log_and_return!({:ok, %{body: %{"errors" => errors}}} = response) do
+  defp log_and_return!({:ok, %{body: %{"errors" => errors}} = response}) do
     error_string =
       errors
       |> Enum.map(&Map.get(&1, "message"))
       |> Enum.join(" ")
 
     Logger.error("#{__MODULE__} call errored: #{error_string}")
-    response
+
+    {:error, response}
   end
 
   defp log_and_return!({:ok, _} = response) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BanyanAPI.MixProject do
   use Mix.Project
 
-  @version "0.4.2"
+  @version "0.4.3"
 
   def project do
     [


### PR DESCRIPTION
## What does this do?
Bubbles up GraphQL errors back to the `Client` instead of logging and swallowing.

## How does this change work?

Invalid GraphQL on the Banyan side still returns an `{:ok, _}` tuple. So far we've just been logging an error message and continuing on our merry way.

Now, we return an error tuple, which should result in a no match exception wherever the client is called (i.e. in a `perform`) which... should make its way to Sentry?

## How do you manually test this?

## When should this be merged?

## What needs to be considered when deploying this?

## Screenshots
