### PR TITLE
Add missing order param

### DIFF
--- a/lib/banyan_api/anonymizers/shopify_order.ex
+++ b/lib/banyan_api/anonymizers/shopify_order.ex
@@ -99,6 +99,7 @@ defmodule BanyanAPI.Anonymizers.ShopifyOrder do
     "currency",
     "customer",
     "discount_applications",
+    "discount_codes",
     "financial_status",
     "id",
     "line_items",

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BanyanAPI.MixProject do
   use Mix.Project
 
-  @version "0.5.2"
+  @version "0.5.3"
 
   def project do
     [


### PR DESCRIPTION
WARNING: This is used to filter orders for segment calls, so this will now pass this along to segment, should be ok?