### PR TITLE
Update actions/cache

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cache dialyzer plts
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: ${{runner.os}}-${{matrix.otp}}-${{matrix.elixir}}-plts


### PR DESCRIPTION
The actions/cache lib is removing most versions on Feb 1/25 https://github.com/actions/cache/releases/tag/v4.2.0

We're fine with just specifying the major version, as we've never had any issues with minor version changes.